### PR TITLE
Fix segment/offset calculation. Fix writes that span multiple segments.

### DIFF
--- a/chains.js
+++ b/chains.js
@@ -74,7 +74,7 @@ function _baseChain(vol) {
             else cb();
         }); else writeMain();
         function writeMain() {
-            var prefaceLen = targetPos.offset,
+            var prefaceLen = (prefaceBuffer) ? prefaceBuffer.length : 0,
                 trailerLen = (data.length - prefaceLen) % chain.sectorSize,
                 mainSector = (prefaceLen) ? targetPos.sector + 1 : targetPos.sector,
                 mainBuffer = (trailerLen) ? data.slice(prefaceLen, -trailerLen) : data.slice(prefaceLen);

--- a/helpers.js
+++ b/helpers.js
@@ -165,7 +165,7 @@ exports.adjustedPos = function (vol, pos, bytes) {
         sector: pos.sector,
         offset: pos.offset + bytes
     }, secSize = vol._sectorSize;
-    while (_pos.offset > secSize) {
+    while (_pos.offset >= secSize) {
         _pos.sector += 1;
         _pos.offset -= secSize;
     }


### PR DESCRIPTION
Thanks for creating this library!

I noticed a problem that not all of the files that I wrote would appear on the floppy drive when I would attach it to a Windows XP virtual machine. When I started debugging this, it looked like if the directory entry write started exactly on a segment, or if a directory entry spanned multiple segments and didn't start at offset 0, then not all of the data would be written.

It looked like this was caused by:
- `segment 0, offset 512` (where 512 is the segment size) should be `segment 1, offset 0`.
- The length of the first buffer written in `writeToPosition` was computed incorrectly.
