### PR TITLE
emit an 'error' event if init() fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,13 @@ exports.createFileSystem = function (volume, opts, cb) {
         volume.readSectors(0, d, function (e) {
             if (e) fs.emit('error', e);
             else {
-                init(d);
+                try {
+                    init(d);
+                } catch (e) {
+                    fs.emit('error', e);
+                    unlock();
+                    return;
+                }
                 fs.emit('ready');
             }
             unlock();


### PR DESCRIPTION
The 'error' event is not emitted when [init](https://github.com/natevw/fatfs/blob/master/index.js#L48) fails.

Here is a simple test case:

```javascript
const fatfs = require('fatfs')

const fat = fatfs.createFileSystem({
	sectorSize: 512,
	numSectors: 1000,
	readSectors: function(sector, dest, callback) {
		// read always returns zeros
		callback(null, Buffer.alloc(dest.length));
	},
	writeSectors: function(sector, data, callback) {
		callback(null, data.length)
	}
});

fat.on('error', function(err) {
	console.log('err', err)
})
fat.on('ready', function() {
	console.log('ready')
})
```

I would expect this code to output 'err' followed by the actual error. Instead it just prints the error and exits.

This PR fixes it.